### PR TITLE
Example: BLoC

### DIFF
--- a/example/lib/src/chroma_counter_bloc/blocs/chroma_counter_cubit.dart
+++ b/example/lib/src/chroma_counter_bloc/blocs/chroma_counter_cubit.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'states/chroma_counter_state.dart';
+
+class ChromaCounterCubit extends Cubit<ChromaCounterState> {
+  ChromaCounterCubit(super.initialState);
+
+  static final _random = math.Random();
+
+  void nextMetamorph() => emit(
+        state.copyWith(
+          count: state.count + 1,
+          backgroundColor: _randomColor(),
+          borderRadius: _randomRadius(),
+        ),
+      );
+
+  Color _randomColor() => Color.fromRGBO(
+        _random.nextInt(256),
+        _random.nextInt(256),
+        _random.nextInt(256),
+        1,
+      );
+
+  BorderRadius _randomRadius() => BorderRadius.only(
+        topLeft: Radius.circular(_random.nextDouble() * 100),
+        topRight: Radius.circular(_random.nextDouble() * 100),
+        bottomLeft: Radius.circular(_random.nextDouble() * 100),
+        bottomRight: Radius.circular(_random.nextDouble() * 100),
+      );
+}

--- a/example/lib/src/chroma_counter_bloc/blocs/states/chroma_counter_state.dart
+++ b/example/lib/src/chroma_counter_bloc/blocs/states/chroma_counter_state.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+@immutable
+class ChromaCounterState extends Equatable {
+  const ChromaCounterState({
+    this.backgroundColor = Colors.blue,
+    this.borderRadius = BorderRadius.zero,
+    this.count = 0,
+  }) : milestone = count ~/ 10;
+
+  final Color backgroundColor;
+  final BorderRadius borderRadius;
+  final int count;
+  final int milestone;
+
+  @override
+  List<Object?> get props => [backgroundColor, borderRadius, count, milestone];
+
+  ChromaCounterState copyWith({
+    final Color? backgroundColor,
+    final BorderRadius? borderRadius,
+    final int? count,
+  }) =>
+      ChromaCounterState(
+        backgroundColor: backgroundColor ?? this.backgroundColor,
+        borderRadius: borderRadius ?? this.borderRadius,
+        count: count ?? this.count,
+      );
+}

--- a/example/lib/src/chroma_counter_bloc/views/chroma_counter_bloc.dart
+++ b/example/lib/src/chroma_counter_bloc/views/chroma_counter_bloc.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../blocs/chroma_counter_cubit.dart';
+import '../blocs/states/chroma_counter_state.dart';
+
+class ChromaCounterBloc extends StatelessWidget {
+  const ChromaCounterBloc({super.key});
+
+  @override
+  Widget build(final BuildContext context) {
+    return BlocBuilder<ChromaCounterCubit, ChromaCounterState>(
+      builder: (final context, final state) {
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.easeInOut,
+          width: 200,
+          height: 200,
+          decoration: BoxDecoration(
+            color: state.backgroundColor,
+            borderRadius: state.borderRadius,
+          ),
+          child: Center(
+            child: Text(
+              '${state.count}',
+              style: const TextStyle(
+                fontSize: 48,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/example/lib/src/chroma_counter_bloc/views/chroma_counter_page.dart
+++ b/example/lib/src/chroma_counter_bloc/views/chroma_counter_page.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+
+import '../blocs/chroma_counter_cubit.dart';
+import '../blocs/states/chroma_counter_state.dart';
+import 'chroma_counter_bloc.dart';
+
+final class ChromaCounterPageBloc extends StatelessWidget {
+  const ChromaCounterPageBloc({super.key});
+
+  @override
+  Widget build(final BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chroma Counter (BLoC)'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          spacing: 32,
+          children: [
+            const _SelectedCount(),
+            const ChromaCounterBloc(),
+            ElevatedButton(
+              onPressed: () {
+                unawaited(
+                  showModalBottomSheet<void>(
+                    context: context,
+                    builder: (final context) => const _BottomSheetContent(),
+                    isScrollControlled: true,
+                    constraints: BoxConstraints(
+                      maxHeight: MediaQuery.of(context).size.height * 0.9,
+                    ),
+                    useSafeArea: true,
+                  ),
+                );
+              },
+              child: const Text('Reveal'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SelectedCount extends StatelessWidget {
+  const _SelectedCount();
+  static final _formatter = DateFormat('mm:ss');
+
+  @override
+  Widget build(final BuildContext context) {
+    return BlocBuilder<ChromaCounterCubit, ChromaCounterState>(
+      builder: (final context, final state) {
+        final now = _formatter.format(DateTime.now());
+        return Text(
+          'Selected: ${state.milestone} at $now',
+          style: Theme.of(context).textTheme.titleMedium,
+        );
+      },
+    );
+  }
+}
+
+class _BottomSheetContent extends StatelessWidget {
+  const _BottomSheetContent();
+
+  @override
+  Widget build(final BuildContext context) {
+    return const SizedBox(
+      width: double.infinity,
+      height: 400,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Center(
+            child: ChromaCounterBloc(),
+          ),
+          Positioned(
+            right: 16,
+            bottom: 32,
+            child: _Button(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Button extends StatelessWidget {
+  const _Button();
+
+  @override
+  Widget build(final BuildContext context) {
+    return FloatingActionButton(
+      onPressed: () => context.read<ChromaCounterCubit>().nextMetamorph(),
+      child: const Icon(Icons.refresh),
+    );
+  }
+}

--- a/example/lib/src/chroma_counter_bloc/views/chroma_counter_page_container.dart
+++ b/example/lib/src/chroma_counter_bloc/views/chroma_counter_page_container.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../blocs/chroma_counter_cubit.dart';
+import '../blocs/states/chroma_counter_state.dart';
+import 'chroma_counter_page.dart';
+
+// This class substitutes whatever class contains MaterialApp. In case of
+// declaring Blocs/Cubits later in the widget tree, it would replace whatever
+// class contains children that would consume Blocs/Cubits.
+class ChromaCounterPageContainer extends StatelessWidget {
+  const ChromaCounterPageContainer({super.key});
+
+  @override
+  Widget build(final BuildContext context) {
+    return BlocProvider(
+      create: (final context) => ChromaCounterCubit(const ChromaCounterState()),
+      child: const ChromaCounterPageBloc(),
+    );
+  }
+}

--- a/example/lib/src/minimal_app.dart
+++ b/example/lib/src/minimal_app.dart
@@ -82,6 +82,18 @@ class HomePage extends StatelessWidget {
                     unawaited(
                       Navigator.of(context).push(
                         MaterialPageRoute(
+                          builder: (final context) => const ChromaCounterPage(),
+                        ),
+                      ),
+                    );
+                  },
+                  child: const Text('Chroma Counter (BLoC)'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    unawaited(
+                      Navigator.of(context).push(
+                        MaterialPageRoute(
                           builder: (final context) => const TodosPage(),
                         ),
                       ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -193,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -222,6 +238,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: "1046d719fbdf230330d3443187cc33cc11963d15c9089f6cc56faa42a4c5f0cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -386,6 +410,14 @@ packages:
       relative: true
     source: path
     version: "2.0.1"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   package_config:
     dependency: transitive
     description:
@@ -426,6 +458,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "489024f942069c2920c844ee18bb3d467c69e48955a4f32d1677f71be103e310"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
   pub_semver:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,8 +8,10 @@ environment:
 
 dependencies:
   dart_mappable: ^4.5.0
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
+  flutter_bloc: ^9.1.0
   flutter_svg: ^2.0.17
   intl: ^0.20.2
   minimal_mvn:


### PR DESCRIPTION
Add BLoC architecture for Chroma Counter feature

- Introduced ChromaCounterCubit and ChromaCounterState for state management.
- Created UI components for Chroma Counter using BLoC pattern.
- Updated pubspec.yaml to include dependencies for equatable and flutter_bloc.
- Added navigation button to HomePage for accessing Chroma Counter.
- Updated pubspec.lock with new package versions.